### PR TITLE
Removed unused and mismatched logger statement from inject

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ var SpecReporter = function(baseReporterDecorator, formatError) {
   this.specFailure = this.writeSpecMessage('FAILED '.red);
 };
 
-SpecReporter.$inject = ['baseReporterDecorator', 'logger', 'formatError'];
+SpecReporter.$inject = ['baseReporterDecorator', 'formatError'];
 
 module.exports = {
   'reporter:spec': ['type', SpecReporter]


### PR DESCRIPTION
When there were errors I it was failing for me every time with "object is not a function." This was because the inject arguments were mismatched. This should fix that.
