### PR TITLE
Changing gray to grey so it's recognized by colors correctly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ var SpecReporter = function(baseReporterDecorator, formatError) {
   };
 
   this.specSuccess = this.writeSpecMessage('PASSED '.green);
-  this.specSkipped = this.writeSpecMessage('SKIPPED'.gray);
+  this.specSkipped = this.writeSpecMessage('SKIPPED'.grey);
   this.specFailure = this.writeSpecMessage('FAILED '.red);
 };
 


### PR DESCRIPTION
When I'm running tests I'm noticing that the skipped ones look like this:

```
  undefined - should populate files object on success
```

This patch changes `.gray` to `.grey` and makes the skipped tests look right:

```
  SKIPPED - should populate files object on success
```

Thanks in advance,
