### PR TITLE
Added options to suppress printing passed/failed/skipped messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,11 +83,13 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       this.write(this.LOG_MULTI_BROWSER, browser, type.toUpperCase(), log);
     }
   };
+  
+  function noop(){}
 
-
-  this.specSuccess = this.writeSpecMessage(this.USE_COLORS ? '✓ '.green : '✓ ');
-  this.specSkipped = this.writeSpecMessage(this.USE_COLORS ? '- '.grey : '- ');
-  this.specFailure = this.writeSpecMessage(this.USE_COLORS ? '✗ '.red : '✗ ');
+  var reporterCfg = config.specReporter || {};
+  this.specSuccess = reporterCfg.suppressPassed ? noop : this.writeSpecMessage(this.USE_COLORS ? '✓ '.green : '✓ ');
+  this.specSkipped = reporterCfg.suppressSkipped ? noop : this.writeSpecMessage(this.USE_COLORS ? '- '.grey : '- ');
+  this.specFailure = reporterCfg.suppressFailed ? noop : this.writeSpecMessage(this.USE_COLORS ? '✗ '.red : '✗ ');
 };
 
 SpecReporter.$inject = ['baseReporterDecorator', 'formatError', 'config'];


### PR DESCRIPTION
The output of this reporter can get very unwieldy for larger test suites. Especially during development, when only a small portion of a test suite is actually executed and most other tests are skipped, this reporter's output is simply unusable. In such a case it will print all tests, whether they are skipped or not. In other configurations, only failed tests are really of any interest, the ones that passed simply clutter the output.

This patch introduces the config option `specReporter` that can be specified in the karma config file. This option has the following format:

```
module.exports = function(config) {
  config.set({
    ....
    reporters : ['spec'],
    specReporter: {
      suppressSkipped: true,
      suppressPassed: true,
      suppressFailed: true
    },
    ....
  });
};
```

The 3 options may be specified as needed (they are all optional) and will suppress printing skipped/failed/passed tests.
