### PR TITLE
Bind refactorings

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,14 +40,14 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       var suite = result.suite
       var indent = "  ";
       suite.forEach(function(value, index) {
-          if (index >= this.currentSuite.length || this.currentSuite[index] != value) {
-            if (index == 0) {
-              this.writeCommonMsg('\n');
-            }
-            this.writeCommonMsg(indent + value + '\n');
-            this.currentSuite = [];
+        if (index >= this.currentSuite.length || this.currentSuite[index] != value) {
+          if (index == 0) {
+            this.writeCommonMsg('\n');
           }
-          indent += "  ";
+          this.writeCommonMsg(indent + value + '\n');
+          this.currentSuite = [];
+        }
+        indent += "  ";
       }, this);
       this.currentSuite = suite;
 


### PR DESCRIPTION
There is no need to explicitely bind an iterator function inside of a forEach(), this is better done by using the second parameter to forEach that allows doing this in a much more readable manner.

This pull request is more of a cosmetical type, it doesn't fix any actual issue with the reporter.
