### PR TITLE
Made colored output more similar to mocha's output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
 
       if(this.USE_COLORS) {
         if(result.skipped) specName = specName.cyan;
-        if(result.success) specName = specName.green;
-        if(result.failed) specName = specName.red;
+        else if(!result.success) specName = specName.red;
       }
 
       var msg = indent + status + specName;


### PR DESCRIPTION
I matched the reporter's output to Mocha's spec reporter. If something goes red or cyan, it's entire message is made that way making it stand out more. See the attached screenshot.

I understand that this is more of a personal taste type thing, so no worries if you reject the PR. For me, I prefer it but ultimately it's your decision!

Cheers.

![screen shot 2014-02-28 at 12 59 45 pm](https://f.cloud.github.com/assets/651740/2296736/a07ed5e2-a0a2-11e3-97e5-136c37ad608d.png)
