### PR TITLE
quieter logging for different config.logLevels 

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
   this.LOG_SINGLE_BROWSER = '%s LOG: %s\n';
   this.LOG_MULTI_BROWSER = '%s %s LOG: %s\n';
   this.onBrowserLog = function(browser, log, type) {
-    if(config.logLevel !== 'INFO' && config.logLevel !== 'DEBUG'){return;}
+    if(config.logLevel === 'DISABLE'  || config.logLevel === 'ERROR' || config.logLevel === 'WARN'){return;}
     if (this._browsers && this._browsers.length === 1) {
       this.write(this.LOG_SINGLE_BROWSER, type.toUpperCase(), this.USE_COLORS ? log.cyan : log);
     } else {


### PR DESCRIPTION
not completely confident about which levels to omit browser logging from, but it is worth tidying up some of the less verbose logging levels :

![screen shot 2014-07-17 at 12 23 53](https://cloud.githubusercontent.com/assets/1065252/3612086/47dfa126-0da5-11e4-8a6d-f6cd43ba2bf0.png)

vs

![screen shot 2014-07-17 at 12 24 37](https://cloud.githubusercontent.com/assets/1065252/3612088/4c10697e-0da5-11e4-8d3a-8fb2491e5c5e.png)
