### PR TITLE
Enable max number of log lines config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,16 @@
 
 Test reporter, that prints detailed results to console (similar to mocha's spec reporter).
 
+To limit the number of lines logged per test 
+``` js
+//karma.conf.js
+...
+  config.set({
+    ...
+      reporters: ["spec"],
+      specReporter: {maxLogLines: 5},
+      plugins: ["karma-spec-reporter"],
+    ...
+```
+
 Take a look at the [karma-spec-reporter-example](http://github.com/mlex/karma-spec-reporter-example) repository to see the reporter in action.

--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       var msg = indent + status + specName;
 
       result.log.forEach(function(log) {
+        if (reporterCfg.maxLogLines) {
+          log = log.split('\n').slice(0, reporterCfg.maxLogLines).join('\n');
+        }
         msg += '\n' + formatError(log, '\t');
       });
 


### PR DESCRIPTION
Sometimes there are an unreasonable number of log lines (eg: stack traces).  
This option allows a limit to be specified.
Somewhat addresses issue #19
