### PR TITLE
Add newline between failed tests in the final report

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,14 +45,18 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
     errors.forEach(function(failure, index) {
       index = index + 1;
 
-      this.writeCommonMsg((index + ') ' + failure.description + '\n').red) ;
+      if (index > 1) {
+        this.writeCommonMsg('\n');
+      }
+
+      this.writeCommonMsg((index + ') ' + failure.description + '\n').red);
       this.writeCommonMsg((this.WHITESPACE + failure.suite.join(' ') + '\n').red);
       failure.log.forEach(function(log) {
         this.writeCommonMsg(this.WHITESPACE + log.replace(/\\n/g, '\n').grey);
       }, this);
     }, this);
 
-    this.writeCommonMsg('\n\n') ;
+    this.writeCommonMsg('\n') ;
   };
 
   this.currentSuite = [];


### PR DESCRIPTION
This commits adds a newline between failed tests in the final report.

This is how it looks currently:

```
1) should succeed if everything is OK
     TuneInIntegrationService saveSettings
     TypeError: 'undefined' is not an object (evaluating 'settings.username = username')
    at http://localhost:9876/base/dev/app/manage/services/TuneInIntegrationService.js?2fc20bcb216d851ad784d39a097964c612a05cf4:4
    at http://localhost:9876/base/dev/app/manage/services/TuneInIntegrationService.tests.js?bc69b9ca7f55a541cad527ecdb0bb4911239972c:472) should fail if the server says so
     TuneInIntegrationService saveSettings
     TypeError: 'undefined' is not an object (evaluating 'settings.username = username')
    at http://localhost:9876/base/dev/app/manage/services/TuneInIntegrationService.js?2fc20bcb216d851ad784d39a097964c612a05cf4:4
```

As you can see, it is very difficult to spot the second failed test
without the colors. With the colors, it is more visible, but it still
does not look good.

This commit fixes this minor display issue and makes it look like this:

```
1) should succeed if everything is OK
     TuneInIntegrationService saveSettings
     TypeError: 'undefined' is not an object (evaluating 'settings.username = username')
    at http://localhost:9876/base/dev/app/manage/services/TuneInIntegrationService.js?2fc20bcb216d851ad784d39a097964c612a05cf4:4
    at http://localhost:9876/base/dev/app/manage/services/TuneInIntegrationService.tests.js?bc69b9ca7f55a541cad527ecdb0bb4911239972c:47
2) should fail if the server says so
     TuneInIntegrationService saveSettings
     TypeError: 'undefined' is not an object (evaluating 'settings.username = username')
    at http://localhost:9876/base/dev/app/manage/services/TuneInIntegrationService.js?2fc20bcb216d851ad784d39a097964c612a05cf4:4
```

…which should be more readable with or without the color.