### PR TITLE
Make to format errors in total section

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       this.writeCommonMsg((index + ') ' + failure.description + '\n').red);
       this.writeCommonMsg((this.WHITESPACE + failure.suite.join(' ') + '\n').red);
       failure.log.forEach(function(log) {
-        this.writeCommonMsg(this.WHITESPACE + log.replace(/\\n/g, '\n').grey);
+        this.writeCommonMsg(this.WHITESPACE + formatError(log).replace(/\\n/g, '\n').grey);
       }, this);
     }, this);
 


### PR DESCRIPTION
Now it seems that reporter outputs errors using source map in list, but without sourcemap in "total" section. Now I get something like this
```

  any
    ✓ good
    ✗ bad
	err
		at /Users/roadhump/ViewGallery/tests.bundle.js:100:32 <- webpack:///src/scripts/screens/StartApp/constants/__tests__/ActionTypes.js:14:0


PhantomJS 2.0.0 (Mac OS X 0.0.0): Executed 2 of 2 (1 FAILED) (0.016 secs / 0.002 secs)
TOTAL: 1 FAILED, 1 SUCCESS


1) bad
     any
     err
	at http://localhost:9876/base/tests.bundle.js?eac38f12aef00c1374baf844349c80091b5c3623:100:32
```

I suppose errors in total section should be the same as in list.

```
  any
    ✓ good
    ✗ bad
	err
		at /Users/roadhump/ViewGallery/tests.bundle.js:100:32 <- webpack:///src/scripts/screens/StartApp/constants/__tests__/ActionTypes.js:14:0


PhantomJS 2.0.0 (Mac OS X 0.0.0): Executed 2 of 2 (1 FAILED) (0.015 secs / 0.001 secs)
TOTAL: 1 FAILED, 1 SUCCESS


1) bad
     any
     err
	at /Users/roadhump/ViewGallery/tests.bundle.js:100:32 <- webpack:///src/scripts/screens/StartApp/constants/__tests__/ActionTypes.js:14:0


```