### PR TITLE
Feature/disable summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Take a look at the [karma-spec-reporter-example](http://github.com/mlex/karma-sp
 
 ## Configuration
 
-To limit the number of lines logged per test 
+To limit the number of lines logged per test
 ``` js
 //karma.conf.js
 ...
@@ -31,5 +31,16 @@ To limit the number of lines logged per test
       plugins: ["karma-spec-reporter"],
     ...
 ```
+### Disabling the error summary
 
-
+To disable the logging of the final errors at the end of the specs being ran
+``` js
+//karma.conf.js
+...
+  config.set({
+    ...
+      reporters: ["spec"],
+      specReporter: {showErrorSummary: false}, //defaults to true
+      plugins: ["karma-spec-reporter"],
+    ...
+```

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
         this.write(this.TOTAL_SUCCESS, results.success);
       } else {
         this.write(this.TOTAL_FAILED, results.failed, results.success);
-        this.logFinalErrors(this.failures);
+        if (this.SHOW_ERROR_SUMMARY) {
+          this.logFinalErrors(this.failures);
+        }
       }
     }
 
@@ -117,6 +119,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       failure: '✗ ',
       skipped: '- '
   };
+  this.SHOW_ERROR_SUMMARY = reporterCfg.showErrorSummary || true;
 
   function noop(){}
   this.onSpecFailure = function(browsers, results) {


### PR DESCRIPTION
I work on a project that runs over 5k+ unit tests. When it fails, the error summary is not useful for reporting as there are multiple failures and the stack trace is already included in the original error reporting. This is a nice to have for people who don't want to see the error summary.