### PR TITLE
fix(reporter): stay consistent with other variables and default to false

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2014 Michael Lex
+Copyright (C) 2015 Michael Lex
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install karma-spec-reporter --save-dev
 ```
 This will download the karma-spec-reporter and add the dependency to `package.json`.
 
-Then add 'spec' to reporters in karma.conf.js, e.g.
+Then add ``'spec'`` to reporters in karma.conf.js, e.g.
 
 ```
 reporters: ['spec']
@@ -20,7 +20,8 @@ Take a look at the [karma-spec-reporter-example](http://github.com/mlex/karma-sp
 
 ## Configuration
 
-To limit the number of lines logged per test
+To limit the number of lines logged per test or suppress specific reporting, use the `specReporter` configuration in your
+karma.conf.js file
 ``` js
 //karma.conf.js
 ...
@@ -28,24 +29,12 @@ To limit the number of lines logged per test
     ...
       reporters: ["spec"],
       specReporter: {
-        maxLogLines: 5         // limit number of lines logged per test
-        suppressPassed: false  // do not print information about passed tests
-        suppressFailed: false  // do not print information about failed tests
+        maxLogLines: 5,         // limit number of lines logged per test
+        suppressErrorSummary: true,  // do not print error summary
+        suppressFailed: false,  // do not print information about failed tests
+        suppressPassed: false,  // do not print information about passed tests
         suppressSkipped: true  // do not print information about skipped tests
       },
-      plugins: ["karma-spec-reporter"],
-    ...
-```
-### Disabling the error summary
-
-To disable the logging of the final errors at the end of the specs being ran
-``` js
-//karma.conf.js
-...
-  config.set({
-    ...
-      reporters: ["spec"],
-      specReporter: {suppressErrorSummary: true}, //defaults to false
       plugins: ["karma-spec-reporter"],
     ...
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To disable the logging of the final errors at the end of the specs being ran
   config.set({
     ...
       reporters: ["spec"],
-      specReporter: {showErrorSummary: false}, //defaults to true
+      specReporter: {suppressErrorSummary: true}, //defaults to false
       plugins: ["karma-spec-reporter"],
     ...
 ```

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
         this.write(this.TOTAL_SUCCESS, results.success);
       } else {
         this.write(this.TOTAL_FAILED, results.failed, results.success);
-        if (!this.specErrorSummary) {
+        if (!this.suppressErrorSummary) {
           this.logFinalErrors(this.failures);
         }
       }
@@ -132,7 +132,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
   this.specSuccess = reporterCfg.suppressPassed ? noop : this.writeSpecMessage(this.USE_COLORS ? prefixes.success.green : prefixes.success);
   this.specSkipped = reporterCfg.suppressSkipped ? noop : this.writeSpecMessage(this.USE_COLORS ? prefixes.skipped.cyan : prefixes.skipped);
   this.specFailure = reporterCfg.suppressFailed ? noop : this.onSpecFailure;
-  this.specErrorSummary = reporterCfg.suppressErrorSummary || false;
+  this.suppressErrorSummary = reporterCfg.suppressErrorSummary || false;
 };
 
 SpecReporter.$inject = ['baseReporterDecorator', 'formatError', 'config'];

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
         this.write(this.TOTAL_SUCCESS, results.success);
       } else {
         this.write(this.TOTAL_FAILED, results.failed, results.success);
-        if (this.SHOW_ERROR_SUMMARY) {
+        if (!this.specErrorSummary) {
           this.logFinalErrors(this.failures);
         }
       }
@@ -122,7 +122,6 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       failure: '✗ ',
       skipped: '- '
   };
-  this.SHOW_ERROR_SUMMARY = reporterCfg.showErrorSummary || true;
 
   function noop(){}
   this.onSpecFailure = function(browsers, results) {
@@ -133,6 +132,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
   this.specSuccess = reporterCfg.suppressPassed ? noop : this.writeSpecMessage(this.USE_COLORS ? prefixes.success.green : prefixes.success);
   this.specSkipped = reporterCfg.suppressSkipped ? noop : this.writeSpecMessage(this.USE_COLORS ? prefixes.skipped.cyan : prefixes.skipped);
   this.specFailure = reporterCfg.suppressFailed ? noop : this.onSpecFailure;
+  this.specErrorSummary = reporterCfg.suppressErrorSummary || false;
 };
 
 SpecReporter.$inject = ['baseReporterDecorator', 'formatError', 'config'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-spec-reporter",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A Karma plugin. Report all spec-results to console (like mocha's spec reporter).",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The original implementation I wrote was incorrect. This fixes the Boolean expression
resolving to its correct value and provides more of a consistent naming pattern.