### PR TITLE
chore(specReporter): enable testing via mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ karma.conf.js file
       plugins: ["karma-spec-reporter"],
     ...
 ```
+
+## Contributing
+
+### Running tests
+
+To run the tests for the index.js file, run: `npm test`
+
+### Generating Coverage
+
+To see the coverage report for the module, run: `npm run coverage`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A Karma plugin. Report all spec-results to console (like mocha's spec reporter).",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha --reporter spec",
+    "coverage": "./node_modules/.bin/istanbul cover -x 'test/**/*.js' ./node_modules/.bin/mocha-runner 'test/**/*.js' html text-summary"
   },
   "repository": {
     "type": "git",
@@ -16,10 +17,15 @@
   ],
   "author": "Michael Lex <michael.lex@codecentric.de>",
   "dependencies": {
-    "colors":"~0.6.0"
+    "colors": "~0.6.0"
   },
   "peerDependencies": {
     "karma": ">=0.9"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^3.4.0",
+    "istanbul": "^0.4.0",
+    "mocha-runner": "^1.1.1"
+  }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,27 @@
+'use strict';
+var should = require('chai').should();
+var SpecReporter = require('../index')['reporter:spec'];
+var formatError = function (a, b) {
+  return a + b;
+};
+var baseReporterDecorator = function () {
+  return {};
+};
+var config = {};
+describe('SpecReporter', function () {
+  describe('when initializing', function () {
+    describe('and colors are not defined', function () {
+      var newSpecReporter;
+      beforeEach(function () {
+        newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+      });
+      it('SpecReporter should be defined appropriately', function () {
+        SpecReporter[0].should.equal('type');
+        newSpecReporter.should.be.a('object');
+      });
+      it('should set USE_COLORS to false', function () {
+        newSpecReporter.USE_COLORS.should.equal(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Also, add ability to generate coverage report for tests.
Added basic unit test for starting point.

This is in reference to #36. @hdavidzhu,  please feel free to add any comments/concerns. This is my first Mocha setup I've ever done.