### PR TITLE
added log line output max lines limitation for failed and successful tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       this.writeCommonMsg((index + ') ' + failure.description + '\n').red);
       this.writeCommonMsg((this.WHITESPACE + failure.suite.join(' ') + '\n').red);
       failure.log.forEach(function(log) {
+        if (reporterCfg.maxLogLines) {
+          log = log.split('\n').slice(0, reporterCfg.maxLogLines).join('\n');
+        } 
         this.writeCommonMsg(this.WHITESPACE + formatError(log).replace(/\\n/g, '\n').grey);
       }, this);
     }, this);


### PR DESCRIPTION
Before this change, the output looked like this, even if maxLogLines was specified:

1) URL validation
     Testing the Model functionality
     Expected false to be truthy.
    at C:/Labs/test/specs/modelSpec.js:13
    at C:/Labs/test/main.js:19
    at C:/Labs/node_modules/requirejs/require.js:1690
    at C:/Labs/node_modules/requirejs/require.js:865
    at C:/Labs/node_modules/requirejs/require.js:1140
    at C:/Labs/node_modules/requirejs/require.js:131
    at C:/Labs/node_modules/requirejs/require.js:1190
    at each (C:/Labs/node_modules/requirejs/require.js:56)
    at C:/Labs/node_modules/requirejs/require.js:1191
    at C:/Labs/node_modules/requirejs/require.js:940
    at C:/Labs/node_modules/requirejs/require.js:1140
    at C:/Labs/node_modules/requirejs/require.js:131
    at C:/Labs/node_modules/requirejs/require.js:1190
    at each (C:/Labs/node_modules/requirejs/require.js:56)
    at C:/Labs/node_modules/requirejs/require.js:1191
    at C:/Labs/node_modules/requirejs/require.js:940
    at C:/Labs/node_modules/requirejs/require.js:1140
    at C:/Labs/node_modules/requirejs/require.js:131
    at C:/Labs/node_modules/requirejs/require.js:1190
    at each (C:/Labs/node_modules/requirejs/require.js:56)
    at C:/Labs/node_modules/requirejs/require.js:1191
    at C:/Labs/node_modules/requirejs/require.js:940
    at C:/Labs/node_modules/requirejs/require.js:1140
    at C:/Labs/node_modules/requirejs/require.js:131
    at C:/Labs/node_modules/requirejs/require.js:1190
    at each (C:/Labs/node_modules/requirejs/require.js:56)

Proposed change fixes the problem.