### PR TITLE
Added 'showSpecTiming' reporter flag to enable appending the elapsed …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ karma.conf.js file
         suppressErrorSummary: true,  // do not print error summary
         suppressFailed: false,  // do not print information about failed tests
         suppressPassed: false,  // do not print information about passed tests
-        suppressSkipped: true  // do not print information about skipped tests
+        suppressSkipped: true,  // do not print information about skipped tests
+        showSpecTiming: false // print the time elapsed for each spec
       },
       plugins: ["karma-spec-reporter"],
     ...

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ require('colors');
 var SpecReporter = function(baseReporterDecorator, formatError, config) {
   baseReporterDecorator(this);
 
+  var reporterCfg = config.specReporter || {};
+  var prefixes = reporterCfg.prefixes || {
+    success: '✓ ',
+    failure: '✗ ',
+    skipped: '- ',
+  };
+
   this.failures = [];
   this.USE_COLORS = false;
 
@@ -74,22 +81,25 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
           if (index === 0) {
             this.writeCommonMsg('\n');
           }
+
           this.writeCommonMsg(indent + value + '\n');
           this.currentSuite = [];
         }
-        indent += "  ";
+
+        indent += '  ';
       }, this);
+
       this.currentSuite = suite;
 
       var specName = result.description;
-      //TODO: add timing information
+      var elapsedTime = reporterCfg.showSpecTiming ? ' (' + result.time + 'ms)' : '';
 
       if(this.USE_COLORS) {
         if(result.skipped) specName = specName.cyan;
         else if(!result.success) specName = specName.red;
       }
 
-      var msg = indent + status + specName;
+      var msg = indent + status + specName + elapsedTime;
 
       result.log.forEach(function(log) {
         if (reporterCfg.maxLogLines) {
@@ -103,9 +113,6 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
       // NOTE: other useful properties
       // browser.id;
       // browser.fullName;
-      // result.time;
-      // result.skipped;
-      // result.success;
     }).bind(this);
   };
 
@@ -119,12 +126,6 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
     }
   };
 
-  var reporterCfg = config.specReporter || {};
-  var prefixes = reporterCfg.prefixes || {
-      success: '✓ ',
-      failure: '✗ ',
-      skipped: '- '
-  };
 
   function noop(){}
   this.onSpecFailure = function(browsers, results) {
@@ -136,6 +137,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
   this.specSkipped = reporterCfg.suppressSkipped ? noop : this.writeSpecMessage(this.USE_COLORS ? prefixes.skipped.cyan : prefixes.skipped);
   this.specFailure = reporterCfg.suppressFailed ? noop : this.onSpecFailure;
   this.suppressErrorSummary = reporterCfg.suppressErrorSummary || false;
+  this.showSpecTiming = reporterCfg.showSpecTiming || false;
 };
 
 SpecReporter.$inject = ['baseReporterDecorator', 'formatError', 'config'];

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,3 +1,5 @@
+/* global beforeEach, it, describe */
+
 'use strict';
 var chai = require('chai');
 var sinon = require('sinon');
@@ -76,6 +78,7 @@ describe('SpecReporter', function () {
         newSpecReporter.TOTAL_FAILED.should.equal(ansiColors.red + 'TOTAL: %d FAILED, %d SUCCESS' + ansiColors.reset + '\n');
       });
     });
+
     describe('and there are configurations set for the spec reporter', function () {
       describe('and suppressFailed is truthy', function () {
         var newSpecReporter;
@@ -91,6 +94,7 @@ describe('SpecReporter', function () {
           expect(newSpecReporter.specFailure()).to.equal();
         });
       });
+
       describe('and suppressSkipped is truthy', function () {
         var newSpecReporter;
         var config = {};
@@ -105,6 +109,7 @@ describe('SpecReporter', function () {
           expect(newSpecReporter.specSkipped()).to.equal();
         });
       });
+
       describe('and suppressPassed is truthy', function () {
         var newSpecReporter;
         var config = {};
@@ -119,6 +124,7 @@ describe('SpecReporter', function () {
           expect(newSpecReporter.specSuccess()).to.equal();
         });
       });
+
       describe('and suppressErrorSummary is truthy', function () {
         var newSpecReporter;
         var config = {};
@@ -133,8 +139,24 @@ describe('SpecReporter', function () {
           newSpecReporter.suppressErrorSummary.should.equal(true);
         });
       });
+
+      describe('and showSpecTiming is truthy', function () {
+        var newSpecReporter;
+        var config = {};
+        beforeEach(function () {
+          config.specReporter = {
+            showSpecTiming: true,
+          };
+          newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+        });
+
+        it('should set the showSpecTiming flag to true', function () {
+          newSpecReporter.showSpecTiming.should.equal(true);
+        });
+      });
     });
   });
+
   describe('functionality', function () {
     describe('onRunComplete', function () {
       describe('with no browsers', function () {
@@ -152,13 +174,16 @@ describe('SpecReporter', function () {
           newSpecReporter.currentSuite.length.should.equal(0);
           newSpecReporter.failures.length.should.equal(0);
         });
+
         it('should call writeCommonMsg', function () {
           newSpecReporter.writeCommonMsg.should.have.been.called;
         });
+
         it('should call write', function () {
           newSpecReporter.write.should.have.been.called;
         });
       });
+
       describe('with browsers', function () {
         describe('and there are no failures', function () {
           var newSpecReporter;
@@ -178,10 +203,12 @@ describe('SpecReporter', function () {
           it('should call to write all of the successful specs', function () {
             newSpecReporter.write.should.have.been.calledWith(undefined, 10);
           });
+
           it('should reset failures and currentSuite arrays', function () {
             newSpecReporter.currentSuite.length.should.equal(0);
             newSpecReporter.failures.length.should.equal(0);
           });
+
           it('should call writeCommonMsg', function () {
             newSpecReporter.writeCommonMsg.should.have.been.called;
           });
@@ -210,17 +237,21 @@ describe('SpecReporter', function () {
             it('should call to write all of the failed and successful specs', function () {
               newSpecReporter.write.should.have.been.calledWith(undefined, 10, 0);
             });
+
             it('should reset failures and currentSuite arrays', function () {
               newSpecReporter.currentSuite.length.should.equal(0);
               newSpecReporter.failures.length.should.equal(0);
             });
+
             it('should call writeCommonMsg', function () {
               newSpecReporter.writeCommonMsg.should.have.been.called;
             });
+
             it('should not call to log the final errors', function () {
               newSpecReporter.logFinalErrors.should.not.have.been.called;
             });
           });
+
           describe('and suppressErrorSummary is false', function () {
             var newSpecReporter;
             var config = {};
@@ -239,13 +270,16 @@ describe('SpecReporter', function () {
             it('should call to write all of the failed and successful specs', function () {
               newSpecReporter.write.should.have.been.calledWith(undefined, 10, 0);
             });
+
             it('should reset failures and currentSuite arrays', function () {
               newSpecReporter.currentSuite.length.should.equal(0);
               newSpecReporter.failures.length.should.equal(0);
             });
+
             it('should call writeCommonMsg', function () {
               newSpecReporter.writeCommonMsg.should.have.been.called;
             });
+
             it('should call to log the final errors', function () {
               newSpecReporter.logFinalErrors.should.have.been.called;
             });


### PR DESCRIPTION
…time that it took to execute each spec. It is off by default, to keep current behavior. Updated README with instructions for the new flag.