### PR TITLE
fix(reporter): don't override windows icons if previously set

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,14 @@ require('colors');
 var SpecReporter = function(baseReporterDecorator, formatError, config) {
   baseReporterDecorator(this);
 
-  var reporterCfg = config.specReporter || {};
+  var reporterCfg = config.specReporter || {},
+      isWindows = (process && process.platform === 'win32');
+      
   this.prefixes = reporterCfg.prefixes || {
-    success: '✓ ',
-    failure: '✗ ',
-    skipped: '- ',
+    success: isWindows ? '\u221A' : '✓ ',
+    failure: isWindows ? '\u00D7' : '✗ ',
+    skipped: isWindows ? '.' : '- ',
   };
-
-  if (process && process.platform === 'win32') {
-    this.prefixes.success = '\u221A';
-    this.prefixes.failure = '\u00D7';
-    this.prefixes.skipped = '.';
-  }
 
   this.failures = [];
   this.USE_COLORS = false;


### PR DESCRIPTION
Closes #56 

This will potentially fail due to coverage, I need to add more tests since overall coverage is being reduced  due to refactoring.
