### PR TITLE
Added space after prefix symbol for Windows platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
   };
 
   if (process && process.platform === 'win32') {
-    this.prefixes.success = '\u221A';
-    this.prefixes.failure = '\u00D7';
-    this.prefixes.skipped = '.';
+    this.prefixes.success = '\u221A ';
+    this.prefixes.failure = '\u00D7 ';
+    this.prefixes.skipped = '- ';
   }
 
   this.failures = [];

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -49,9 +49,9 @@ var ansiColors = {
   reset: '\u001b[39m'
 };
 var windowsIcons = {
-  success: '\u221A',
-  failure: '\u00D7',
-  skipped: '.'
+  success: '\u221A ',
+  failure: '\u00D7 ',
+  skipped: '- '
 }
 
 //baseReporterDecorator functions


### PR DESCRIPTION
Since space exists in prefixes for non Windows platform.
Also modified the symbol for pending from . to - to keep it consistent with non windows platform symbol
