### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "author": "Michael Lex <michael.lex@codecentric.de>",
   "dependencies": {
-    "colors": "~0.6.0"
+    "colors": "^1.1.2"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
colors.js version 0.6.0 (which is a dependency of karma-spec-reporter) was unlicensed (which can be problematic, since this means karma-spec-reporter is legally not licensed too).

These changes update colors to latest version, which removes this licensing problem.

The API didn't change in our usage.

Once you merge this, can you please publish a new npm version ?
