### PR TITLE
Added summaryOnly flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ karma.conf.js file
       specReporter: {
         maxLogLines: 5,         // limit number of lines logged per test
         suppressErrorSummary: true,  // do not print error summary
+        summaryOnly: false		// do not print any inline log info for failed tests
         suppressFailed: false,  // do not print information about failed tests
         suppressPassed: false,  // do not print information about passed tests
         suppressSkipped: true,  // do not print information about skipped tests

--- a/index.js
+++ b/index.js
@@ -107,13 +107,15 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
 
       var msg = indent + status + specName + elapsedTime;
 
-      result.log.forEach(function(log) {
-        if (reporterCfg.maxLogLines) {
-          log = log.split('\n').slice(0, reporterCfg.maxLogLines).join('\n');
-        }
-        msg += '\n' + formatError(log, '\t');
-      });
-
+      if (!reporterCfg.summaryOnly) {
+	      result.log.forEach(function(log) {
+	        if (reporterCfg.maxLogLines) {
+	          log = log.split('\n').slice(0, reporterCfg.maxLogLines).join('\n');
+	        }
+	        msg += '\n' + formatError(log, '\t');
+	      });
+      }
+      
       this.writeCommonMsg(msg + '\n');
 
       // NOTE: other useful properties

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
 
       var msg = indent + status + specName + elapsedTime;
 
-      if (!reporterCfg.summaryOnly) {
+      if (!this.summaryOnly) {
 	      result.log.forEach(function(log) {
 	        if (reporterCfg.maxLogLines) {
 	          log = log.split('\n').slice(0, reporterCfg.maxLogLines).join('\n');
@@ -144,6 +144,7 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
   this.specSuccess = reporterCfg.suppressPassed ? noop : this.writeSpecMessage(this.USE_COLORS ? this.prefixes.success.green : this.prefixes.success);
   this.specSkipped = reporterCfg.suppressSkipped ? noop : this.writeSpecMessage(this.USE_COLORS ? this.prefixes.skipped.cyan : this.prefixes.skipped);
   this.specFailure = reporterCfg.suppressFailed ? noop : this.onSpecFailure;
+  this.summaryOnly = reporterCfg.summaryOnly || false;
   this.suppressErrorSummary = reporterCfg.suppressErrorSummary || false;
   this.showSpecTiming = reporterCfg.showSpecTiming || false;
 };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -203,19 +203,34 @@ describe('SpecReporter', function () {
       });
 
       describe('and showSpecTiming is truthy', function () {
-        var newSpecReporter;
-        var config = {};
-        beforeEach(function () {
-          config.specReporter = {
-            showSpecTiming: true,
-          };
-          newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+          var newSpecReporter;
+          var config = {};
+          beforeEach(function () {
+            config.specReporter = {
+              showSpecTiming: true,
+            };
+            newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+          });
+
+          it('should set the showSpecTiming flag to true', function () {
+            newSpecReporter.showSpecTiming.should.equal(true);
+          });
         });
 
-        it('should set the showSpecTiming flag to true', function () {
-          newSpecReporter.showSpecTiming.should.equal(true);
+      describe('and summaryOnly is truthy', function () {
+          var newSpecReporter;
+          var config = {};
+          beforeEach(function () {
+            config.specReporter = {
+            	summaryOnly: true,
+            };
+            newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+          });
+
+          it('should set the summaryOnly flag to true', function () {
+            newSpecReporter.summaryOnly.should.equal(true);
+          });
         });
-      });
     });
   });
 


### PR DESCRIPTION
Looks like it's behaving, only affects the main top area not the summary.

Handy for doing a grab from the console and including in daily reports to the powers that be. They don't care about why things fail, they just want to be impressed by a big list of tests and see the red going away over the weeks of development.
