### PR TITLE
feat(reporter) add fail fast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ karma.conf.js file
     ...
       reporters: ["spec"],
       specReporter: {
-        maxLogLines: 5,         // limit number of lines logged per test
-        suppressErrorSummary: true,  // do not print error summary
-        suppressFailed: false,  // do not print information about failed tests
-        suppressPassed: false,  // do not print information about passed tests
-        suppressSkipped: true,  // do not print information about skipped tests
-        showSpecTiming: false // print the time elapsed for each spec
+        maxLogLines: 5,             // limit number of lines logged per test
+        suppressErrorSummary: true, // do not print error summary
+        suppressFailed: false,      // do not print information about failed tests
+        suppressPassed: false,      // do not print information about passed tests
+        suppressSkipped: true,      // do not print information about skipped tests
+        showSpecTiming: false,      // print the time elapsed for each spec
+        failFast: true              // test would finish with error when a first fail occurs. 
       },
       plugins: ["karma-spec-reporter"],
     ...

--- a/index.js
+++ b/index.js
@@ -137,6 +137,9 @@ var SpecReporter = function(baseReporterDecorator, formatError, config) {
   this.onSpecFailure = function(browsers, results) {
     this.failures.push(results);
     this.writeSpecMessage(this.USE_COLORS ? this.prefixes.failure.red : this.prefixes.failure).apply(this, arguments);
+    if (reporterCfg.failFast) {
+      throw new Error('Fail fast active for tests, exiting(failFast option is enabled)');
+    }
   };
 
   this.specSuccess = reporterCfg.suppressPassed ? noop : this.writeSpecMessage(this.USE_COLORS ? this.prefixes.success.green : this.prefixes.success);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -349,5 +349,26 @@ describe('SpecReporter', function () {
         });
       });
     });
+    
+    describe('onSpecFailure', function () {
+      describe('with FAIL_FAST option', function () {
+        var newSpecReporter;
+        var config = {};
+        beforeEach(function () {
+          config.specReporter = {
+            failFast: true
+          };
+          newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+        });
+        it('should throw an error', function () {
+          expect(function () {
+            newSpecReporter.onSpecFailure([],{
+              suite: [],
+              log: []
+            })
+          }).to.throw(Error, /failFast/);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Add fail-fast feature.

If you add failFast option to reporterCfg, reporter would throw error when a first fail occurs.

``` js
//karma.conf.js
...
  config.set({
    ...
      reporters: ["spec"],
      specReporter: {
        failFast: true
      },
      plugins: ["karma-spec-reporter"],
    ...
```
