### PR TITLE
fix(reporter): allow prefix overrides on win32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+node_js: "4"
 sudo: false
 script: "npm run-script coverage"
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/index.js
+++ b/index.js
@@ -3,18 +3,16 @@ require('colors');
 var SpecReporter = function (baseReporterDecorator, formatError, config) {
   baseReporterDecorator(this);
 
-  var reporterCfg = config.specReporter || {};
-  this.prefixes = reporterCfg.prefixes || {
-      success: '✓ ',
-      failure: '✗ ',
-      skipped: '- ',
-    };
-
-  if (process && process.platform === 'win32') {
-    this.prefixes.success = '\u221A ';
-    this.prefixes.failure = '\u00D7 ';
-    this.prefixes.skipped = '- ';
+  var platform = process ? process.platform : 'unknown';
+  var selectPrefix = function(defaultMarker, win32Marker) {
+    return platform === 'win32' ? win32Marker : defaultMarker;
   }
+  var reporterCfg = config.specReporter || {};
+  this.prefixes = Object.assign({
+      success: selectPrefix('✓ ', '\u221A '),
+      failure: selectPrefix('✗ ', '\u00D7 '),
+      skipped: selectPrefix('- ', '\- ')
+    }, reporterCfg.prefixes);
 
   this.failures = [];
   this.USE_COLORS = false;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha-runner --reporter spec test/**/*.spec.js",
-    "coverage": "istanbul cover -x test/**/*.js ./node_modules/.bin/mocha-runner -- --reporter spec test/**/*.js"
+    "coverage": "istanbul cover -x test/**/*.js node_modules/mocha/bin/_mocha -- --reporter spec test/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha-runner --reporter spec test/**/*.spec.js",
-    "coverage": "istanbul cover -x test/**/*.js node_modules/mocha/bin/_mocha -- --reporter spec test/**/*.js"
+    "coverage": "istanbul cover -x test/**/*.js node_modules/mocha/bin/_mocha -- --reporter spec test/**/*.js",
+    "precoverage-report": "run-s coverage",
+    "coverage-report": "istanbul report"
   },
   "repository": {
     "type": "git",
@@ -28,6 +30,7 @@
     "coveralls": "^2.11.4",
     "istanbul": "^0.4.0",
     "mocha-runner": "^1.1.1",
+    "npm-run-all": "^4.0.2",
     "rewire": "^2.5.1",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A Karma plugin. Report all spec-results to console (like mocha's spec reporter).",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha-runner --reporter spec 'test/**/*.spec.js'",
-    "coverage": "./node_modules/.bin/istanbul cover -x 'test/**/*.js' ./node_modules/.bin/mocha-runner -- --reporter spec 'test/**/*.js'"
+    "test": "mocha-runner --reporter spec test/**/*.spec.js",
+    "coverage": "istanbul cover -x test/**/*.js ./node_modules/.bin/mocha-runner -- --reporter spec test/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chai": "^3.4.0",
     "coveralls": "^2.11.4",
     "istanbul": "^0.4.0",
+    "mocha": "^3.2.0",
     "mocha-runner": "^1.1.1",
     "npm-run-all": "^4.0.2",
     "rewire": "^2.5.1",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -100,7 +100,7 @@ describe('SpecReporter', function () {
         }
       }
       it('SpecReporter should allow overriding success icon only', function () {
-        var expected = 'PASS'; 
+        var expected = 'PASS';
         var config = createConfigWithPrefixes({ success: expected });
         var newSpecReporter = createSpecReporter(config);
         newSpecReporter.prefixes.success.should.equal(expected);
@@ -109,7 +109,7 @@ describe('SpecReporter', function () {
       });
 
       it('SpecReporter should allow overriding failure icon only', function () {
-        var expected = 'FAIL'; 
+        var expected = 'FAIL';
         var config = createConfigWithPrefixes({ failure: expected });
         var newSpecReporter = createSpecReporter(config);
         newSpecReporter.prefixes.success.should.equal(windowsIcons.success);
@@ -118,7 +118,7 @@ describe('SpecReporter', function () {
       });
 
       it('SpecReporter should allow overriding skipped icon only', function () {
-        var expected = 'SKIPPED'; 
+        var expected = 'SKIPPED';
         var config = createConfigWithPrefixes({ skipped: expected });
         var newSpecReporter = createSpecReporter(config);
         newSpecReporter.prefixes.success.should.equal(windowsIcons.success);
@@ -127,7 +127,7 @@ describe('SpecReporter', function () {
       });
 
       it('SpecReporter should allow overriding all icons', function () {
-        var config = createConfigWithPrefixes({ 
+        var config = createConfigWithPrefixes({
           skipped: 'Skipped',
           failure: 'Failed',
           success: 'Win!'
@@ -394,6 +394,98 @@ describe('SpecReporter', function () {
             });
           });
         });
+      });
+    });
+
+    describe('logFinalErrors', function () {
+      var writtenMessages = [];
+      beforeEach(function () {
+        writtenMessages = [];
+      });
+      function passThrough(str) {
+        return str;
+      }
+      function createSpecReporter(options) {
+        var result = new SpecReporter[1](baseReporterDecorator, passThrough, options || {});
+        result.writeCommonMsg = function (str) {
+          writtenMessages.push(str);
+        };
+        return result;
+      }
+      
+      it('should write a single failure out', function () {
+        var errors = [
+          {
+            suite: ['A', 'B'],
+            description: 'should do stuff',
+            log: [
+              'The Error!'
+            ]
+          }
+        ];
+        var expected = ['\n\n',
+          '\u001b[31m1) should do stuff\n\u001b[39m',
+          '\u001b[31m     A B\n\u001b[39m',
+          '     \u001b[90mThe Error!\u001b[39m',
+          '\n'];
+        var specReporter = createSpecReporter();
+        specReporter.logFinalErrors(errors);
+        writtenMessages.should.eql(expected);
+      });
+
+      it('should truncate messages exceding maxLogLines in length', function () {
+        var errors = [
+          {
+            suite: ['A', 'B'],
+            description: 'should do stuff',
+            log: [
+              'The Error!\nThis line should be discarded'
+            ]
+          }
+        ];
+        var expected = ['\n\n',
+          '\u001b[31m1) should do stuff\n\u001b[39m',
+          '\u001b[31m     A B\n\u001b[39m',
+          '     \u001b[90mThe Error!\u001b[39m',
+          '\n'];
+        var specReporter = createSpecReporter({
+          specReporter: {
+            maxLogLines: 1
+          }
+        });
+        specReporter.logFinalErrors(errors);
+        writtenMessages.should.eql(expected);
+      });
+
+      it('should write out multiple failures', function () {
+        var errors = [
+          {
+            suite: ['A', 'B'],
+            description: 'should do stuff',
+            log: [
+              'The Error!'
+            ]
+          },
+          {
+            suite: ['C', 'D'],
+            description: 'should do more stuff',
+            log: [
+              'Another error!'
+            ]
+          }
+        ];
+        var expected = ['\n\n',
+          '\u001b[31m1) should do stuff\n\u001b[39m',
+          '\u001b[31m     A B\n\u001b[39m',
+          '     \u001b[90mThe Error!\u001b[39m',
+          '\n',         
+          '\u001b[31m2) should do more stuff\n\u001b[39m',
+          '\u001b[31m     C D\n\u001b[39m',
+          '     \u001b[90mAnother error!\u001b[39m',
+          '\n'];
+        var specReporter = createSpecReporter();
+        specReporter.logFinalErrors(errors);
+        writtenMessages.should.eql(expected);
       });
     });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -59,7 +59,7 @@ var windowsIcons = {
 var formatError = function (a, b) {
   return a + b;
 };
-function noop() {}
+function noop() { }
 var baseReporterDecorator = function (context) {
   context.renderBrowser = sinon.spy();
   context.writeCommonMsg = sinon.spy();
@@ -130,28 +130,15 @@ describe('SpecReporter', function () {
       });
 
       it('should set the BaseReporter function\'s colors', function () {
-        //NOTE: this is temporary as the colors module was updated
-        if (os.platform() === 'win32') {
-            newSpecReporter.SPEC_FAILURE.should.equal('%s %s FAILED\n');
-            newSpecReporter.SPEC_SLOW.should.equal('%s SLOW %s: %s\n');
-            newSpecReporter.ERROR.should.equal('%s ERROR\n');
-            newSpecReporter.FINISHED_ERROR.should.equal(' ERROR');
-            newSpecReporter.FINISHED_SUCCESS.should.equal(' SUCCESS');
-            newSpecReporter.FINISHED_DISCONNECTED.should.equal(' DISCONNECTED');
-            newSpecReporter.X_FAILED.should.equal(' (%d FAILED)');
-            newSpecReporter.TOTAL_SUCCESS.should.equal('TOTAL: %d SUCCESS\n');
-            newSpecReporter.TOTAL_FAILED.should.equal('TOTAL: %d FAILED, %d SUCCESS\n');
-        } else {
-            newSpecReporter.SPEC_FAILURE.should.equal(ansiColors.red + '%s %s FAILED' + ansiColors.reset + '\n');
-            newSpecReporter.SPEC_SLOW.should.equal(ansiColors.yellow + '%s SLOW %s: %s' + ansiColors.reset + '\n');
-            newSpecReporter.ERROR.should.equal(ansiColors.red + '%s ERROR' + ansiColors.reset + '\n');
-            newSpecReporter.FINISHED_ERROR.should.equal(ansiColors.red + ' ERROR' + ansiColors.reset);
-            newSpecReporter.FINISHED_SUCCESS.should.equal(ansiColors.green + ' SUCCESS' + ansiColors.reset);
-            newSpecReporter.FINISHED_DISCONNECTED.should.equal(ansiColors.red + ' DISCONNECTED' + ansiColors.reset);
-            newSpecReporter.X_FAILED.should.equal(ansiColors.red + ' (%d FAILED)' + ansiColors.reset);
-            newSpecReporter.TOTAL_SUCCESS.should.equal(ansiColors.green + 'TOTAL: %d SUCCESS' + ansiColors.reset + '\n');
-            newSpecReporter.TOTAL_FAILED.should.equal(ansiColors.red + 'TOTAL: %d FAILED, %d SUCCESS' + ansiColors.reset + '\n');
-        }
+        newSpecReporter.SPEC_FAILURE.should.equal(ansiColors.red + '%s %s FAILED' + ansiColors.reset + '\n');
+        newSpecReporter.SPEC_SLOW.should.equal(ansiColors.yellow + '%s SLOW %s: %s' + ansiColors.reset + '\n');
+        newSpecReporter.ERROR.should.equal(ansiColors.red + '%s ERROR' + ansiColors.reset + '\n');
+        newSpecReporter.FINISHED_ERROR.should.equal(ansiColors.red + ' ERROR' + ansiColors.reset);
+        newSpecReporter.FINISHED_SUCCESS.should.equal(ansiColors.green + ' SUCCESS' + ansiColors.reset);
+        newSpecReporter.FINISHED_DISCONNECTED.should.equal(ansiColors.red + ' DISCONNECTED' + ansiColors.reset);
+        newSpecReporter.X_FAILED.should.equal(ansiColors.red + ' (%d FAILED)' + ansiColors.reset);
+        newSpecReporter.TOTAL_SUCCESS.should.equal(ansiColors.green + 'TOTAL: %d SUCCESS' + ansiColors.reset + '\n');
+        newSpecReporter.TOTAL_FAILED.should.equal(ansiColors.red + 'TOTAL: %d FAILED, %d SUCCESS' + ansiColors.reset + '\n');
       });
     });
 
@@ -376,7 +363,7 @@ describe('SpecReporter', function () {
         });
         it('should throw an error', function () {
           expect(function () {
-            newSpecReporter.onSpecFailure([],{
+            newSpecReporter.onSpecFailure([], {
               suite: [],
               log: []
             })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -69,10 +69,8 @@ var baseReporterDecorator = function (context) {
 describe('SpecReporter', function () {
   describe('when initializing', function () {
     describe('and on a windows machine', function () {
-      var newSpecReporter;
-      var config = {};
-
-      beforeEach(function () {
+      function createSpecReporter(config) {
+        config = config || {};
         var processMock = {
           platform: function () {
             return 'win32';
@@ -84,13 +82,61 @@ describe('SpecReporter', function () {
             platform: 'win32'
           }
         });
-        newSpecReporter = new reporterRewire['reporter:spec'][1](baseReporterDecorator, formatError, config);
-      });
+        return new reporterRewire['reporter:spec'][1](baseReporterDecorator, formatError, config);
+      };
 
       it('SpecReporter should have icons defined appropriately', function () {
+        var newSpecReporter = createSpecReporter();
         newSpecReporter.prefixes.success.should.equal(windowsIcons.success);
         newSpecReporter.prefixes.failure.should.equal(windowsIcons.failure);
         newSpecReporter.prefixes.skipped.should.equal(windowsIcons.skipped);
+      });
+
+      function createConfigWithPrefixes(prefixes) {
+        return {
+          specReporter: {
+            prefixes: prefixes
+          }
+        }
+      }
+      it('SpecReporter should allow overriding success icon only', function () {
+        var expected = 'PASS'; 
+        var config = createConfigWithPrefixes({ success: expected });
+        var newSpecReporter = createSpecReporter(config);
+        newSpecReporter.prefixes.success.should.equal(expected);
+        newSpecReporter.prefixes.failure.should.equal(windowsIcons.failure);
+        newSpecReporter.prefixes.skipped.should.equal(windowsIcons.skipped);
+      });
+
+      it('SpecReporter should allow overriding failure icon only', function () {
+        var expected = 'FAIL'; 
+        var config = createConfigWithPrefixes({ failure: expected });
+        var newSpecReporter = createSpecReporter(config);
+        newSpecReporter.prefixes.success.should.equal(windowsIcons.success);
+        newSpecReporter.prefixes.failure.should.equal(expected);
+        newSpecReporter.prefixes.skipped.should.equal(windowsIcons.skipped);
+      });
+
+      it('SpecReporter should allow overriding skipped icon only', function () {
+        var expected = 'SKIPPED'; 
+        var config = createConfigWithPrefixes({ skipped: expected });
+        var newSpecReporter = createSpecReporter(config);
+        newSpecReporter.prefixes.success.should.equal(windowsIcons.success);
+        newSpecReporter.prefixes.failure.should.equal(windowsIcons.failure);
+        newSpecReporter.prefixes.skipped.should.equal(expected);
+      });
+
+      it('SpecReporter should allow overriding all icons', function () {
+        var config = createConfigWithPrefixes({ 
+          skipped: 'Skipped',
+          failure: 'Failed',
+          success: 'Win!'
+        });
+        var expected = config.specReporter.prefixes;
+        var newSpecReporter = createSpecReporter(config);
+        newSpecReporter.prefixes.success.should.equal(expected.success);
+        newSpecReporter.prefixes.failure.should.equal(expected.failure);
+        newSpecReporter.prefixes.skipped.should.equal(expected.skipped);
       });
     });
     describe('and colors are not defined', function () {


### PR DESCRIPTION
Similar to #57, which seems to have been abandoned, though implemented quite differently.

In addition to adding tests for the functionality I wanted to add, I've also:

- Made the npm scripts run cross-platform (they were failing on Windows; this has been checked on Linux)
- Remove the win32-specific branch of color testing as the color package does the right thing now (and this test was failing on win32 before I removed that block)
- Add a coverage-report npm script to generate the html coverage report as required (which is how I found code to cover)
- Add coverage for final error reporting, just to bring coverage up a bit, since I've seen warnings in other PRs about coverage dropping and I thought it might be a nice thing to do (: