### PR TITLE
fix(colors): Set colors.enabled = true when colors is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-require('colors');
+var colors = require('colors');
 
 var SpecReporter = function (baseReporterDecorator, formatError, config) {
   baseReporterDecorator(this);
@@ -19,6 +19,7 @@ var SpecReporter = function (baseReporterDecorator, formatError, config) {
 
   // colorize output of BaseReporter functions
   if (config.colors) {
+    colors.enabled = true;
     this.USE_COLORS = true;
     this.SPEC_FAILURE = '%s %s FAILED'.red + '\n';
     this.SPEC_SLOW = '%s SLOW %s: %s'.yellow + '\n';


### PR DESCRIPTION
@mlex Fixes an issue when piping test output where colors are not transferred. Setting colors.enabled = true fixes the issue. 

Reference issues that led me to the fix:
https://github.com/Marak/colors.js/issues/127
https://github.com/bcaudan/jasmine-spec-reporter/commit/9bc1bc24c40cc796618ead4950d57b1ebb7382ca
