### PR TITLE
Add a suppressSummary option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "8"
   - "7"
   - "6"
-  - "4"
 sudo: false
 script: "npm run-script coverage"
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ karma.conf.js file
       reporters: ["spec"],
       specReporter: {
         maxLogLines: 5,             // limit number of lines logged per test
+        suppressSummary: true,      // do not print summary
         suppressErrorSummary: true, // do not print error summary
         suppressFailed: false,      // do not print information about failed tests
         suppressPassed: false,      // do not print information about passed tests

--- a/index.js
+++ b/index.js
@@ -35,14 +35,20 @@ var SpecReporter = function (baseReporterDecorator, formatError, config) {
 
   this.onRunComplete = function (browsers, results) {
     //NOTE: the renderBrowser function is defined in karma/reporters/Base.js
-    this.writeCommonMsg('\n' + browsers.map(this.renderBrowser)
-        .join('\n') + '\n');
+    if (!this.suppressSummary) {
+      this.writeCommonMsg('\n' + browsers.map(this.renderBrowser)
+          .join('\n') + '\n');
+    }
 
     if (browsers.length >= 1 && !results.disconnected && !results.error) {
       if (!results.failed) {
-        this.write(this.TOTAL_SUCCESS, results.success);
+        if (!this.suppressSummary) {
+          this.write(this.TOTAL_SUCCESS, results.success);
+        }
       } else {
-        this.write(this.TOTAL_FAILED, results.failed, results.success);
+        if (!this.suppressSummary) {
+          this.write(this.TOTAL_FAILED, results.failed, results.success);
+        }
         if (!this.suppressErrorSummary) {
           this.logFinalErrors(this.failures);
         }
@@ -194,6 +200,7 @@ var SpecReporter = function (baseReporterDecorator, formatError, config) {
     ? noop
     : this.writeSpecMessage(this.USE_COLORS ? this.prefixes.skipped.cyan : this.prefixes.skipped);
   this.specFailure = reporterCfg.suppressFailed ? noop : this.onSpecFailure;
+  this.suppressSummary = reporterCfg.suppressSummary || false;
   this.suppressErrorSummary = reporterCfg.suppressErrorSummary || false;
   this.showSpecTiming = reporterCfg.showSpecTiming || false;
   this.reportSlowerThan = config.reportSlowerThan || false;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -236,6 +236,21 @@ describe('SpecReporter', function() {
         });
       });
 
+      describe('and suppressSummary is truthy', function () {
+        var newSpecReporter;
+        var config = {};
+        beforeEach(function() {
+          config.specReporter = {
+            suppressSummary: true
+          };
+          newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+        });
+
+        it('should set the suppressSummary flag to true', function() {
+          newSpecReporter.suppressSummary.should.equal(true);
+        });
+      })
+
       describe('and suppressErrorSummary is truthy', function() {
         var newSpecReporter;
         var config = {};
@@ -297,31 +312,67 @@ describe('SpecReporter', function() {
 
       describe('with browsers', function() {
         describe('and there are no failures', function() {
-          var newSpecReporter;
-          var config = {};
+          describe('and suppressSummary is true', function() {
+            var newSpecReporter;
+            var config = {
+              specReporter: {
+                suppressSummary: true
+              }
+            };
 
-          beforeEach(function() {
-            newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
-            newSpecReporter.currentSuite.push('suite name');
-            newSpecReporter.onRunComplete(['testValue'], {
-              disconnected: false,
-              error: false,
-              failed: 0,
-              success: 10
+            beforeEach(function() {
+              newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+              newSpecReporter.currentSuite.push('suite name');
+              newSpecReporter.onRunComplete(['testValue'], {
+                disconnected: false,
+                error: false,
+                failed: 0,
+                success: 10
+              });
+            });
+
+            it('should not call to write all of the successful specs', function() {
+              newSpecReporter.write.should.have.been.calledOnce;
+              newSpecReporter.write.should.have.been.calledWithExactly('\n');
+            });
+
+            it('should reset failures and currentSuite arrays', function() {
+              newSpecReporter.currentSuite.length.should.equal(0);
+              newSpecReporter.failures.length.should.equal(0);
+            });
+
+            it('should not call writeCommonMsg', function() {
+              newSpecReporter.writeCommonMsg.should.not.have.been.called;
             });
           });
 
-          it('should call to write all of the successful specs', function() {
-            newSpecReporter.write.should.have.been.calledWith(undefined, 10);
-          });
+          describe('and suppressSummary is false', function() {
+            var newSpecReporter;
+            var config = {};
 
-          it('should reset failures and currentSuite arrays', function() {
-            newSpecReporter.currentSuite.length.should.equal(0);
-            newSpecReporter.failures.length.should.equal(0);
-          });
+            beforeEach(function() {
+              newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError, config);
+              newSpecReporter.currentSuite.push('suite name');
+              newSpecReporter.onRunComplete(['testValue'], {
+                disconnected: false,
+                error: false,
+                failed: 0,
+                success: 10
+              });
+            });
 
-          it('should call writeCommonMsg', function() {
-            newSpecReporter.writeCommonMsg.should.have.been.called;
+            it('should call to write all of the successful specs', function() {
+              newSpecReporter.write.should.have.been.calledWith(undefined, 10);
+            });
+
+            it('should reset failures and currentSuite arrays', function() {
+              newSpecReporter.currentSuite.length.should.equal(0);
+              newSpecReporter.failures.length.should.equal(0);
+            });
+
+            it('should call writeCommonMsg', function() {
+              newSpecReporter.writeCommonMsg.should.have.been.called;
+            });
           });
         });
 


### PR DESCRIPTION
Resolves https://github.com/mlex/karma-spec-reporter/issues/83

The PR adds a `suppressSummary` options, that (when equal `true`) prevents the reporter from printing browser summary lines and the general summary line.